### PR TITLE
Add Diskord

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can find a list of Discord API libraries here. Libraries are sorted alphabet
 - [flask-discord-interactions](https://github.com/Breq16/flask-discord-interactions "flask-discord-interactions")<sup>[3]</sup>
 - [hata](https://github.com/HuyaneMatsu/hata "hata")
 - [hikari-py](https://github.com/hikari-py/hikari "hikari-py")
+- [diskord](https://github.com/diskord-dev/diskord "diskord")<sup>[6]</sup>
 
 ### [Racket](https://racket-lang.org "Racket")
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ You can find a list of Discord API libraries here. Libraries are sorted alphabet
 - [discord-interactions-python](https://github.com/discord/discord-interactions-python "discord-interactions-python")<sup>[3]</sup>
 - [discord-py-slash-command](https://github.com/eunwoo1104/discord-py-slash-command "discord-py-slash-command")<sup>[3][4]</sup>
 - ~~[discord.py](https://github.com/Rapptz/discord.py "discord.py")~~
+- [diskord](https://github.com/diskord-dev/diskord "diskord")<sup>[6]</sup>
 - [dislash.py](https://github.com/EQUENOS/dislash.py "dislash.py")<sup>[3][4]</sup>
 - [dispike](https://github.com/ms7m/dispike "dispike")<sup>[3]</sup>
 - [flask-discord-interactions](https://github.com/Breq16/flask-discord-interactions "flask-discord-interactions")<sup>[3]</sup>

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ You can find a list of Discord API libraries here. Libraries are sorted alphabet
 - [flask-discord-interactions](https://github.com/Breq16/flask-discord-interactions "flask-discord-interactions")<sup>[3]</sup>
 - [hata](https://github.com/HuyaneMatsu/hata "hata")
 - [hikari-py](https://github.com/hikari-py/hikari "hikari-py")
-- [diskord](https://github.com/diskord-dev/diskord "diskord")<sup>[6]</sup>
 
 ### [Racket](https://racket-lang.org "Racket")
 


### PR DESCRIPTION
This pull request adds my fork of discord.py in this list.

It is, of course written in Python and the source of the library can be found [here](https://github.com/diskord-dev/diskord).

The master branch is currently developing application commands but aren't in production ready state yet and the stable version can be installed by:
```sh
pip install diskord
```
stable version doesn't has application commands yet. If any other information is required, Feel free to let me know.