### PR TITLE
DisCatSharp is a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can find a list of Discord API libraries here. Libraries are sorted alphabet
 
 ### [.NET](https://dotnet.microsoft.com ".NET")
 
-- [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp "DisCatSharp")[^1][^2]
+- [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp "DisCatSharp")[^1][^2][^4]
 - [discord-rpc-csharp](https://github.com/Lachee/discord-rpc-csharp "discord-rpc-chsarp")[^5]
 - [Discord.Net](https://github.com/RogueException/Discord.Net "Discord.Net")
 - [Discord.Net Labs](https://github.com/Discord-Net-Labs/Discord.Net-Labs "Discord.Net-Labs")[^6]


### PR DESCRIPTION
As can be seen by looking at the [Initial Commit](https://github.com/Aiko-IT-Systems/DisCatSharp/commit/90be2535a2626c2ecf0f5fa17f9157965d8da415), which just copies all the code from [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus). I assume in an attempt to remove contribution credits from the original authors.