### PR TITLE
Striked discordcr

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can find a list of Discord API libraries here. Libraries are sorted alphabet
 
 ### [Crystal](https://crystal-lang.org "Crystal")
 
-- [discordcr](https://github.com/discordcr/discordcr "discordcr")
+- ~~[discordcr](https://github.com/discordcr/discordcr "discordcr")~~
 
 ### [D](https://dlang.org "D")
 


### PR DESCRIPTION
The discordcr library has been archived by the owner and hasn't had any releases since 2018.