### PR TITLE
Removed token logger

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -225,21 +225,6 @@
     "tags": [],
     "urls": {}
   },
-  "DisCatSharp": {
-    "language": "C#",
-    "repository_url": "https://github.com/Aiko-IT-Systems/DisCatSharp",
-    "description": "Your library to write discord bots in C# with focus on always providing access to the latest discord features.",
-    "license": "Other",
-    "created_at": "2021-06-28",
-    "features": [
-      "gateway",
-      "rest"
-    ],
-    "tags": [
-      "fork"
-    ],
-    "urls": {}
-  },
   "discljord": {
     "language": "Clojure",
     "repository_url": "https://github.com/discljord/discljord",


### PR DESCRIPTION
Since this is a curated listed, I figured it shouldn't be recommending shameless plagiarised libraries with built in token logging and home calling.