### PR TITLE
Update Discordcr

### DIFF
--- a/data/repositories.json
+++ b/data/repositories.json
@@ -28,7 +28,7 @@
   "https://github.com/discord/discord-interactions-php",
   "https://github.com/discord/discord-interactions-python",
   "https://github.com/Discord4J/Discord4J",
-  "https://github.com/discordcr/discordcr",
+  "https://github.com/shardlab/discordcr",
   "https://github.com/discordeno/discordeno",
   "https://github.com/discordjs/discord.js",
   "https://github.com/discordjs/voice",


### PR DESCRIPTION
Discordcr moved to the shardlab organization a while back and is now being maintained there: https://github.com/shardlab/discordcr